### PR TITLE
Remove Deprecated warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def get_require_version(name):
     return require
 
 config = ConfigParser()
-config.readfp(open('tryton.cfg'))
+config.read_file(open('tryton.cfg'))
 info = dict(config.items('tryton'))
 for key in ('depends', 'extras_depend', 'xml'):
     if key in info:


### PR DESCRIPTION
setup.py:31: DeprecationWarning: This method will be removed in future versions.  Use 'parser.read_file()' instead.
  config.readfp(open('tryton.cfg'))